### PR TITLE
Nullable Parameters in Expect Functions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.winterbe</groupId>
     <artifactId>expekt</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.4.1-SNAPSHOT</version>
     <name>Expekt</name>
     <description>BDD assertion library for Kotlin</description>
     <url>https://github.com/winterbe/expekt</url>

--- a/src/main/kotlin/com/winterbe/expekt/Expekt.kt
+++ b/src/main/kotlin/com/winterbe/expekt/Expekt.kt
@@ -4,7 +4,7 @@ fun <T> expect(subject: T?): ExpectAny<T?> {
     return ExpectAny(subject, Flavor.EXPECT)
 }
 
-fun expect(subject: Boolean): ExpectBoolean {
+fun expect(subject: Boolean?): ExpectBoolean {
     return ExpectBoolean(subject, Flavor.EXPECT)
 }
 
@@ -16,15 +16,15 @@ fun expect(subject: Double?): ExpectDouble {
     return ExpectDouble(subject, Flavor.EXPECT)
 }
 
-fun expect(subject: String): ExpectString {
+fun expect(subject: String?): ExpectString {
     return ExpectString(subject, Flavor.EXPECT)
 }
 
-fun <T> expect(subject: Collection<T>): ExpectCollection<T> {
+fun <T> expect(subject: Collection<T>?): ExpectCollection<T> {
     return ExpectCollection(subject, Flavor.EXPECT)
 }
 
-fun <K, V> expect(subject: Map<K, V>): ExpectMap<K, V> {
+fun <K, V> expect(subject: Map<K, V>?): ExpectMap<K, V> {
     return ExpectMap(subject, Flavor.EXPECT)
 }
 

--- a/src/test/kotlin/com/winterbe/expekt/ExpectBooleanTest.kt
+++ b/src/test/kotlin/com/winterbe/expekt/ExpectBooleanTest.kt
@@ -37,6 +37,14 @@ class ExpectBooleanTest {
     }
 
     @Test
+    fun `null`() {
+        passes { expect(null as Boolean?).to.be.`null` }
+        fails("expect false to be null") {
+            expect(false).to.be.`null`
+        }
+    }
+
+    @Test
     fun should() {
         true.should.be.`true`
     }

--- a/src/test/kotlin/com/winterbe/expekt/ExpectCollectionTest.kt
+++ b/src/test/kotlin/com/winterbe/expekt/ExpectCollectionTest.kt
@@ -138,6 +138,14 @@ class ExpectCollectionTest {
     }
 
     @Test
+    fun `null`() {
+        passes { expect(null as Collection<Int>?).to.be.`null` }
+        fails("expect [1, 2, 3] to be null") {
+            expect(listOf(1, 2, 3)).to.be.`null`
+        }
+    }
+
+    @Test
     fun should() {
         listOf(1, 2, 3).should.contain.all.elements(1, 2)
     }

--- a/src/test/kotlin/com/winterbe/expekt/ExpectMapTest.kt
+++ b/src/test/kotlin/com/winterbe/expekt/ExpectMapTest.kt
@@ -148,4 +148,10 @@ class ExpectMapTest {
         passes { mapOf(1 to 2).should.not.be.empty }
     }
 
+    @Test
+    fun `null`() {
+        passes { expect(null as Map<Int, Int>?).to.be.`null` }
+        fails("expect {a=1} to be null") { expect(mapOf("a" to 1)).to.be.`null` }
+    }
+
 }

--- a/src/test/kotlin/com/winterbe/expekt/ExpectStringTest.kt
+++ b/src/test/kotlin/com/winterbe/expekt/ExpectStringTest.kt
@@ -132,6 +132,14 @@ class ExpectStringTest {
     }
 
     @Test
+    fun `null`() {
+        passes { expect(null as String?).to.be.`null` }
+        fails("expect abc to be null") {
+            expect("abc").to.be.`null`
+        }
+    }
+
+    @Test
     fun should() {
         "abc".should.startWith("a").and.endWith("bc")
     }


### PR DESCRIPTION
Fixing parameter definitions in expect functions for String, Boolean, Collection, and Map to accept nullable types.
