### PR TITLE
(feat) Add expect() and should for Sequence<T>

### DIFF
--- a/src/main/kotlin/com/winterbe/expekt/Expekt.kt
+++ b/src/main/kotlin/com/winterbe/expekt/Expekt.kt
@@ -24,6 +24,10 @@ fun <T> expect(subject: Collection<T>?): ExpectCollection<T> {
     return ExpectCollection(subject, Flavor.EXPECT)
 }
 
+fun <T> expect(subject: Sequence<T>?): ExpectCollection<T> {
+    return ExpectCollection(subject?.toList(), Flavor.EXPECT)
+}
+
 fun <K, V> expect(subject: Map<K, V>?): ExpectMap<K, V> {
     return ExpectMap(subject, Flavor.EXPECT)
 }
@@ -50,6 +54,10 @@ val Double?.should: ExpectDouble get() {
 
 val <T> Collection<T>?.should: ExpectCollection<T> get() {
     return ExpectCollection(this, Flavor.SHOULD)
+}
+
+val <T> Sequence<T>?.should: ExpectCollection<T> get() {
+    return ExpectCollection(this?.toList(), Flavor.SHOULD)
 }
 
 val <K, V> Map<K, V>?.should: ExpectMap<K, V> get() {

--- a/src/test/kotlin/com/winterbe/expekt/ExpectSequenceTest.kt
+++ b/src/test/kotlin/com/winterbe/expekt/ExpectSequenceTest.kt
@@ -1,0 +1,153 @@
+package com.winterbe.expekt
+
+import org.junit.Test
+
+class ExpectSequenceTest {
+
+    @Test
+    fun elementsHaveAny() {
+        passes { expect(sequenceOf(1, 2, 3)).to.contain.any.elements(1, 2, 3) }
+        passes { expect(sequenceOf(1, 2, 3)).to.contain.any.elements(1, 4) }
+        fails("expect [1, 2, 3] to contain any elements [4, 5]") {
+            expect(sequenceOf(1, 2, 3)).to.contain.any.elements(4, 5)
+        }
+    }
+
+    @Test
+    fun elementsHaveAll() {
+        passes { expect(sequenceOf(1, 2, 3)).to.have.all.elements(1, 2, 3) }
+        fails("expect [1, 2, 3] to have all elements [1, 2]") { expect(sequenceOf(1, 2, 3)).to.have.all.elements(1, 2) }
+        fails { expect(sequenceOf(1, 2, 3)).to.have.all.elements(1) }
+        fails { expect(sequenceOf(1, 2, 3)).to.have.all.elements(1, 2, 3, 4) }
+    }
+
+    @Test
+    fun elementsHaveImplicitAll() {
+        passes { expect(sequenceOf(1, 2, 3)).to.have.elements(1, 2, 3) }
+        fails("expect [1, 2, 3] to have elements [1, 2]") { expect(sequenceOf(1, 2, 3)).to.have.elements(1, 2) }
+        fails { expect(sequenceOf(1, 2, 3)).to.have.elements(1) }
+        fails { expect(sequenceOf(1, 2, 3)).to.have.elements(1, 2, 3, 4) }
+    }
+
+    @Test
+    fun elementsContainAny() {
+        passes { expect(sequenceOf(1, 2, 3)).to.contain.any.elements(1, 2, 3) }
+        passes { expect(sequenceOf(1, 2, 3)).to.contain.any.elements(1, 4) }
+        fails("expect [1, 2, 3] to contain any elements [4, 5]") {
+            expect(sequenceOf(1, 2, 3)).to.contain.any.elements(4, 5)
+        }
+    }
+
+    @Test
+    fun elementsContainAll() {
+        passes { expect(sequenceOf(1, 2, 3)).to.contain.all.elements(1, 2, 3) }
+        passes { expect(sequenceOf(1, 2, 3)).to.contain.all.elements(1, 2) }
+        passes { expect(sequenceOf(1, 2, 3)).to.contain.all.elements(1) }
+        fails("expect [1, 2, 3] to contain all elements [1, 2, 4]") {
+            expect(sequenceOf(1, 2, 3)).to.contain.all.elements(1, 2, 4)
+        }
+    }
+
+    @Test
+    fun elementsContainImplicitAll() {
+        passes { expect(sequenceOf(1, 2, 3)).to.contain.elements(1, 2, 3) }
+        passes { expect(sequenceOf(1, 2, 3)).to.contain.elements(1, 2) }
+        passes { expect(sequenceOf(1, 2, 3)).to.contain.elements(1) }
+        fails("expect [1, 2, 3] to contain elements [1, 2, 4]") {
+            expect(sequenceOf(1, 2, 3)).to.contain.elements(1, 2, 4)
+        }
+    }
+
+    @Test
+    fun containsLength() {
+        passes { expect(sequenceOf(1, 2, 3)).to.contain(3).and.to.have.size.above(2) }
+    }
+
+    @Test
+    fun notContain() {
+        passes { expect(sequenceOf(1, 2, 3)).not.to.contain(4) }
+        fails("expect [1, 2, 3] not to contain 3") {
+            expect(sequenceOf(1, 2, 3)).not.to.contain(3)
+        }
+    }
+
+    @Test
+    fun contain() {
+        passes { expect(sequenceOf(1, 2, 3)).to.contain(1) }
+        fails("expect [1, 2, 3] to contain 4") { expect(sequenceOf(1, 2, 3)).to.contain(4) }
+    }
+
+    @Test
+    fun notSizeProp() {
+        passes { expect(sequenceOf(1, 2, 3)).not.to.have.size.above(3) }
+        fails("expect [1, 2, 3] not to have size below 4") {
+            expect(sequenceOf(1, 2, 3)).not.to.have.size.below(4)
+        }
+    }
+
+    @Test
+    fun sizeProp() {
+        passes { expect(sequenceOf(1, 2, 3)).to.have.size.above(2) }
+        fails("expect [1, 2, 3] to have size equal 4") {
+            expect(sequenceOf(1, 2, 3)).to.have.size.equal(4)
+        }
+    }
+
+    @Test
+    fun notSize() {
+        passes { expect(sequenceOf(1, 2, 3)).not.to.have.size(4) }
+        fails("expect [1, 2, 3] not to have size 3") { expect(sequenceOf(1, 2, 3)).not.to.have.size(3) }
+    }
+
+    @Test
+    fun size() {
+        passes { expect(sequenceOf(1, 2, 3)).to.have.size(3) }
+        fails("expect [1, 2, 3] to have size 4") { expect(sequenceOf(1, 2, 3)).to.have.size(4) }
+    }
+
+    @Test
+    fun notEmpty() {
+        passes { expect(sequenceOf(1, 2, 3)).not.to.be.empty }
+        fails("expect [] not to be empty") {
+            expect(sequenceOf<Int>()).not.to.be.empty
+        }
+    }
+
+    @Test
+    fun empty() {
+        passes { expect(sequenceOf<Int>()).to.be.empty }
+        fails("expect [1, 2, 3] to be empty") {
+            expect(sequenceOf(1, 2, 3)).to.be.empty
+        }
+    }
+
+    @Test
+    fun notEquals() {
+//        passes { expect(sequenceOf(1, 2, 3)).not.to.equal(sequenceOf(1, 2, 3, 4)) }
+//        fails("expect [1, 2, 3] not to equal [1, 2, 3]") {
+//            expect(sequenceOf(1, 2, 3)).not.to.equal(sequenceOf(1, 2, 3))
+//        }
+    }
+
+    @Test
+    fun equals() {
+//        passes { expect(sequenceOf(1, 2, 3)).to.equal(sequenceOf(1, 2, 3)) }
+//        fails("expect [1, 2, 3] to equal [1, 2, 3, 4]") {
+//            expect(sequenceOf(1, 2, 3)).to.equal(sequenceOf(1, 2, 3, 4))
+//        }
+    }
+
+    @Test
+    fun `null`() {
+        passes { expect(null as Sequence<Int>?).to.be.`null` }
+        fails("expect [1, 2, 3] to be null") {
+            expect(sequenceOf(1, 2, 3)).to.be.`null`
+        }
+    }
+
+    @Test
+    fun should() {
+        sequenceOf(1, 2, 3).should.contain.all.elements(1, 2)
+    }
+
+}


### PR DESCRIPTION
- It simply uses `ExpectCollection(sequence.toList())`.
- It can not handle infinite sequences.
- It needs a list instead of a sequence when using `to.equal()` or `not.to.equal()`.

**Examples:**

``` kotlin
expect(sequenceOf(1, 2, 3)).to.contain.any.elements(1, 2, 3)
expect(sequenceOf(1, 2, 3)).to.contain.any.elements(1, 4)
```
